### PR TITLE
Add instructions to retrieve client certificate and key from Minikube…

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ kubectl proxy --address=0.0.0.0 --accept-hosts='.*'
 
 <img src="https://i.sstatic.net/YGIVx.png" alt="Set Public Port" width="50%">
 
+5. Get the client.crt and client.key from ```/home/vscode/.minikube/profiles/minikube``` .
+
 
 ## Minikube dashboard
 For more information on how to make the Minikube dashboard accessible on all IPs (0.0.0.0), refer to [this link](https://unix.stackexchange.com/questions/621369/how-can-i-make-the-minikube-dashboard-answer-on-all-ips-0-0-0-0).


### PR DESCRIPTION
This pull request includes a minor update to the `README.md` file. The change adds a step to retrieve the `client.crt` and `client.key` files from the Minikube profiles directory.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R104-R105): Added instructions to get `client.crt` and `client.key` from `/home/vscode/.minikube/profiles/minikube`.