### PR TITLE
Modify instruction handling

### DIFF
--- a/k8s-grader-api/common-layer/common/file.py
+++ b/k8s-grader-api/common-layer/common/file.py
@@ -31,5 +31,6 @@ def create_json_input(endpoint, extra_data=None):
         "host": endpoint,
     }
     json_input.update(extra_data)
+    del json_input["$instruction"]
     with open("/tmp/json_input.json", "w", encoding="utf-8") as json_file:
         json.dump(json_input, json_file)

--- a/k8s-grader-api/grader/app.py
+++ b/k8s-grader-api/grader/app.py
@@ -176,6 +176,6 @@ def lambda_handler(event, context):  # pylint: disable=W0613
         game_phrase,
         next_game_phrase,
         test_result,
-        f"{game_phrase.value} in {test_result.name}.",
+        f"{game_phrase.value} in {test_result.name}.{session['$instruction']}",
         report_url,
     )


### PR DESCRIPTION
This pull request includes changes to the `k8s-grader-api` project, specifically focusing on modifying how instructions are handled in the JSON input and lambda handler. The most important changes involve removing the `$instruction` key from the JSON input and appending it to the test result message in the lambda handler.

Changes to instruction handling:

* [`k8s-grader-api/common-layer/common/file.py`](diffhunk://#diff-e462fab852619ce2b64325b74ef6bd79428c7780369d46a9986bf47f5a229c2cR34): Deleted the `$instruction` key from the `json_input` dictionary before writing it to a file.
* [`k8s-grader-api/grader/app.py`](diffhunk://#diff-833bea7d44012496a013fe83afb3bec217e080832768e1f0eb5d5b45e95a968bL179-R179): Appended the `$instruction` value from the session to the test result message string.