### PR TITLE
Adjust AI chat probability threshold from 0.5 to 0.3

### DIFF
--- a/k8s-grader-api/game_task/app.py
+++ b/k8s-grader-api/game_task/app.py
@@ -62,7 +62,7 @@ def lambda_handler(event, context):  # pylint: disable=W0613
             f"NPC {npc} or main character not found in the bachground database"
         )
 
-    if random.random() < 0.5:
+    if random.random() < 0.3:
         message = get_ai_random_chat(npc)
         if message is None:
             message = "..."


### PR DESCRIPTION
This pull request includes a small change to the `k8s-grader-api/game_task/app.py` file. The change modifies the probability threshold for generating a random chat message from 0.5 to 0.3.

* [`k8s-grader-api/game_task/app.py`](diffhunk://#diff-28995e32fc32ffac317b2ba075f1c16aa5acc1f150cd7a4defb334bdea645ef0L65-R65): Changed the probability threshold in the `lambda_handler` function to 0.3 for generating a random chat message.